### PR TITLE
mac fixes

### DIFF
--- a/BlackmagicRAWHandler.cpp
+++ b/BlackmagicRAWHandler.cpp
@@ -438,9 +438,7 @@ void BlackmagickRAWRendererCallback::ReadComplete(IBlackmagicRawJob *readJob,
         gamut.bstrVal = bgamut;
         SysFreeString(bgamut);
 #elif __APPLE__
-        CFStringRef cfgamut = CFStringCreateWithCString(kCFAllocatorDefault, specs.gamut.c_str(), kCFStringEncodingUTF8);
-        gamut.bstrVal = cfgamut;
-        CFRelease(cfgamut);
+        gamut.bstrVal = CFStringCreateWithCString(NULL, specs.gamut.c_str(), kCFStringEncodingUTF8);
 #else
         gamut.bstrVal = specs.gamut.c_str();
 #endif
@@ -457,9 +455,7 @@ void BlackmagickRAWRendererCallback::ReadComplete(IBlackmagicRawJob *readJob,
         gamma.bstrVal = bgamma;
         SysFreeString(bgamma);
 #elif __APPLE__
-        CFStringRef cfgamma = CFStringCreateWithCString(kCFAllocatorDefault, specs.gamma.c_str(), kCFStringEncodingUTF8);
-        gamma.bstrVal = cfgamma;
-        CFRelease(cfgamma);
+        gamma.bstrVal =  CFStringCreateWithCString(kCFAllocatorDefault, specs.gamma.c_str(), kCFStringEncodingUTF8);
 #else
         gamma.bstrVal = specs.gamma.c_str();
 #endif
@@ -525,6 +521,9 @@ void BlackmagickRAWRendererCallback::ReadComplete(IBlackmagicRawJob *readJob,
 
     // set quality (scale)
     switch (specs.quality) {
+    case BlackmagicRAWHandler::rawFullQuality:
+        result = frame->SetResolutionScale(blackmagicRawResolutionScaleFullUpsideDown);
+        break;
     case BlackmagicRAWHandler::rawHalfQuality:
         result = frame->SetResolutionScale(blackmagicRawResolutionScaleHalfUpsideDown);
         break;
@@ -535,7 +534,7 @@ void BlackmagickRAWRendererCallback::ReadComplete(IBlackmagicRawJob *readJob,
         result = frame->SetResolutionScale(blackmagicRawResolutionScaleEighthUpsideDown);
         break;
     default:
-        result = frame->SetResolutionScale(blackmagicRawResolutionScaleFullUpsideDown);
+        result = E_INVALIDARG;
     }
 
     // setup and run job

--- a/BlackmagicRAWPlugin.cpp
+++ b/BlackmagicRAWPlugin.cpp
@@ -446,17 +446,19 @@ bool BlackmagicRAWPlugin::getFrameBounds(const std::string& filename,
             }
         }
     }
-    if (width > 0 && height > 0) {
-        bounds->x1 = 0;
-        bounds->x2 = width;
-        _bounds.x2 = width; // cache
-        bounds->y1 = 0;
-        bounds->y2 = height;
-        _bounds.y2 = height; // cache
-        *format = *bounds;
-        *par = 1.0;
+    if (width <= 0 || height <= 0) {
+        return false;
     }
+    bounds->x1 = 0;
+    bounds->x2 = width;
+    _bounds.x2 = width; // cache
+    bounds->y1 = 0;
+    bounds->y2 = height;
+    _bounds.y2 = height; // cache
+    *format = *bounds;
+    *par = 1.0;
     *tile_width = *tile_height = 0;
+
     return true;
 }
 
@@ -540,7 +542,7 @@ const std::string BlackmagicRAWPlugin::getLibraryPath()
     result = pfiles;
     result.append("\\Adobe\\Common\\Plug-ins\\7.0\\MediaCore\\BlackmagicRawAPI");
 #elif __APPLE__
-    result = "/Applications/Blackmagic\\ RAW/Blackmagic\\ RAW\\ SDK/Mac/Libraries";
+    result = "/Applications/Blackmagic RAW/Blackmagic RAW SDK/Mac/Libraries";
 #else
     result = "/usr/lib/blackmagic/BlackmagicRAWSDK/Linux/Libraries";
 #endif


### PR DESCRIPTION
builds, doesn't crash, but still can't read because callback.frameBuffer == nullptr (using braw sdk 2.0)